### PR TITLE
option: change separator, preventing attribute confusion

### DIFF
--- a/app/code/community/Pimgento/Api/Model/Job/Product.php
+++ b/app/code/community/Pimgento/Api/Model/Job/Product.php
@@ -633,7 +633,7 @@ class Pimgento_Api_Model_Job_Product extends Pimgento_Api_Model_Job_Abstract
             $columnParts = explode('-', $column, 2);
             /** @var string $columnPrefix */
             $columnPrefix = reset($columnParts);
-            $columnPrefix = sprintf('%s_', $columnPrefix);
+            $columnPrefix = sprintf('%s-', $columnPrefix);
             /** @var int $prefixLength */
             $prefixLength = strlen($columnPrefix) + 1;
             /** @var string $entitiesTable */

--- a/app/code/community/Pimgento/Api/Model/Resource/Entities.php
+++ b/app/code/community/Pimgento/Api/Model/Resource/Entities.php
@@ -509,7 +509,7 @@ class Pimgento_Api_Model_Resource_Entities extends Mage_Core_Model_Resource_Db_A
             /** @var string $oldEntityCodeColumnName */
             $oldEntityCodeColumnName = sprintf('CONCAT(t.`%s`, "_", t.`%s`)', $prefix, $entityCode);
             /** @var string $update */
-            $update = 'UPDATE `' . $pimgentoTable . '` AS `e`, `' . $tableName . '` AS `t` SET e.code = ' . $entityCodeColumnName . ' WHERE e.code = ' . $oldEntityCodeColumnName;
+            $update = 'UPDATE `' . $pimgentoTable . '` AS `e`, `' . $tableName . '` AS `t` SET e.code = ' . $entityCodeColumnName . ' WHERE e.code = ' . $oldEntityCodeColumnName . ' AND e.`import` = "' . $import . '"';
 
             $adapter->query($update);
         }

--- a/app/code/community/Pimgento/Api/Model/Resource/Entities.php
+++ b/app/code/community/Pimgento/Api/Model/Resource/Entities.php
@@ -502,7 +502,16 @@ class Pimgento_Api_Model_Resource_Entities extends Mage_Core_Model_Resource_Db_A
         /** @var string $entityCodeColumnName */
         $entityCodeColumnName = sprintf('t.`%s`', $entityCode);
         if ($prefix !== '') {
-            $entityCodeColumnName = sprintf('CONCAT(t.`%s`, "_", t.`%s`)', $prefix, $entityCode);
+            /* Use new error-free separator */
+            $entityCodeColumnName = sprintf('CONCAT(t.`%s`, "-", t.`%s`)', $prefix, $entityCode);
+
+            /* Legacy: update columns still using former "_" separator */
+            /** @var string $oldEntityCodeColumnName */
+            $oldEntityCodeColumnName = sprintf('CONCAT(t.`%s`, "_", t.`%s`)', $prefix, $entityCode);
+            /** @var string $update */
+            $update = 'UPDATE `' . $pimgentoTable . '` AS `e`, `' . $tableName . '` AS `t` SET e.code = ' . $entityCodeColumnName . ' WHERE e.code = ' . $oldEntityCodeColumnName;
+
+            $adapter->query($update);
         }
 
         /* Update entity_id column from pimgento_entities table */
@@ -560,9 +569,9 @@ class Pimgento_Api_Model_Resource_Entities extends Mage_Core_Model_Resource_Db_A
         /** @var string $maxCode */
         $maxCode = $adapter->fetchOne(
             $adapter->select()->from($pimgentoTable, new Zend_Db_Expr(sprintf('MAX(`%s`)', $entitiesIdFieldName)))->where(
-                    'import = ?',
-                    $import
-                )
+                'import = ?',
+                $import
+            )
         );
         /** @var string $maxEntity */
         $maxEntity = $adapter->fetchOne(


### PR DESCRIPTION
option: change separator, preventing attribute confusion while replacing option code by entity_id, add legacy update